### PR TITLE
Fix bullet typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
                         <li><strong>Provincia de Buenos Aires:</strong> 2% de las utilidades brutas mensuales.</li>
                         <li><strong>Córdoba:</strong> 34% del "net win" (ganancia neta).</li>
                         <li><strong>Salta:</strong> Canon mensual y tasa de fiscalización según Ley N° 7.020.</li>
-                        <li><strong>Mendoza:S</strong> Canon único establecido por el Instituto Provincial de Juegos y Casinos.</li>
+                        <li><strong>Mendoza:</strong> Canon único establecido por el Instituto Provincial de Juegos y Casinos.</li>
                     </ul>
                 </div>
 


### PR DESCRIPTION
## Summary
- fix Mendoza licensing bullet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840753203e88331b19271835c995ee0